### PR TITLE
native_googleads: 0.0.2 — preloaded banner/native demos + production ID validation

### DIFF
--- a/packages/native_googleads/CHANGELOG.md
+++ b/packages/native_googleads/CHANGELOG.md
@@ -14,3 +14,19 @@ The format follows Keep a Changelog and this project adheres to Semantic Version
 - Helper widgets: `BannerAdWidget` and `NativeAdWidget`.
 - Configuration via `AdConfig` and `AdRequestConfig`.
 - Built-in Google test ad unit IDs and example app.
+## [0.0.2] - 2025-08-22
+
+### Added
+- Preloaded rendering support for widgets:
+  - `BannerAdWidget(preloadedBannerId: ...)`
+  - `NativeAdWidget(preloadedNativeAdId: ...)`
+- Production/test ID validation policy in Dart:
+  - Warn or throw on Google test IDs in release; configurable via `setAdIdValidationPolicy`.
+- New example pages: Preloaded Banner, Preloaded Native, and Preloaded Fullscreen Ads; UI overflow fixes and graceful failure handling.
+
+### Changed
+- README and example docs updated to remove unimplemented features and reflect current APIs.
+- Example: renamed UI actions to “Preload” for interstitial/rewarded; removed Multi-Preload Manager demo.
+
+### Tests
+- Unit tests for validation policy behavior (warn-only, strict, and disabled modes).

--- a/packages/native_googleads/example/README.md
+++ b/packages/native_googleads/example/README.md
@@ -115,6 +115,31 @@ final rewardedAdUnitId = Platform.isAndroid
 await _ads.preloadRewardedAd(adUnitId: rewardedAdUnitId);
 ```
 
+#### Preloaded Fullscreen Ads (Demo Page)
+
+The example includes a dedicated page to experience preloading behavior for interstitial and rewarded ads:
+
+- Navigate to: Home → "Preloaded Fullscreen Ads"
+- Actions per ad type:
+  - Preload: loads and warms the cache
+  - Check Ready: queries native cache state
+  - Show: displays when ready
+- After dismiss or failure, native code auto-preloads next; the UI reflects readiness after a short delay.
+
+#### Preloaded Banner (Demo Page)
+
+- Flow: tap Preload to call `loadBannerAd(...)`, then render via `BannerAdWidget(preloadedBannerId: ...)`.
+- Notes:
+  - Widget accepts a preloaded banner ID to skip internal loading.
+  - On iOS, prefer the widget approach over programmatic `showBannerAd` to place the banner in the layout.
+
+#### Preloaded Native (Demo Page)
+
+- Flow: tap Preload to call `loadNativeAd(...)`, then render via `NativeAdWidget(preloadedNativeAdId: ...)`.
+- Notes:
+  - Widget accepts a preloaded native ad ID to skip internal loading.
+  - On failure, the card is skipped to keep content flow natural.
+
 #### Setting Up Callbacks
 
 ```dart
@@ -141,7 +166,10 @@ _ads.setAdCallbacks(
 late final String interstitialId;
 
 Future<void> initAds() async {
-  await _ads.initializeWithConfig(AdConfig.test());
+  // Initialize with test App ID for development
+  await _ads.initialize(appId: Platform.isAndroid
+      ? AdTestIds.androidAppId
+      : AdTestIds.iosAppId);
   interstitialId = Platform.isAndroid
       ? AdTestIds.androidInterstitial
       : AdTestIds.iosInterstitial;
@@ -198,6 +226,15 @@ The example app includes:
    - Load button
    - Show button (enabled when ad is ready)
    - Status indicator
+5. **Preloaded Fullscreen Ads**:
+   - Combined page for Interstitial + Rewarded
+   - Preload / Check Ready / Show controls
+   - Shows auto-preload behavior after dismissal
+
+### Handling Load Failures Gracefully
+
+- Banner Ads: if loading fails, the banner slot is hidden automatically, avoiding awkward blank space.
+- Native Ads: the demo skips the native ad insertion when load fails, letting content flow naturally.
 
 ## Troubleshooting
 
@@ -234,3 +271,9 @@ To use in production:
 ## License
 
 MIT - See LICENSE file for details
+ 
+---
+
+Notes:
+- When using `BannerAdWidget` in the example, do not call `showBannerAd`/`hideBannerAd`; the PlatformView attaches the banner inside the widget.
+- On iOS, the programmatic `showBannerAd` API attaches banners to the root view controller, not inside a widget tree.

--- a/packages/native_googleads/example/pubspec.lock
+++ b/packages/native_googleads/example/pubspec.lock
@@ -160,7 +160,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   path:
     dependency: transitive
     description:

--- a/packages/native_googleads/example/test/widget_test.dart
+++ b/packages/native_googleads/example/test/widget_test.dart
@@ -6,6 +6,7 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart' show Scrollable; // for scrollUntilVisible
 
 import 'package:native_googleads_example/main.dart';
 
@@ -19,10 +20,21 @@ void main() {
     // Verify that the app title is shown
     expect(find.text('Native Google Ads Demo'), findsOneWidget);
 
-    // Verify that ad type cards are present
+    // Verify that ad type cards are present (scroll if needed)
     expect(find.text('Banner Ads'), findsOneWidget);
     expect(find.text('Native Ads'), findsOneWidget);
     expect(find.text('Interstitial Ads'), findsOneWidget);
-    expect(find.text('Rewarded Ads'), findsOneWidget);
+
+    // The list may require scrolling for the last item after adding new entries
+    final rewardedFinder = find.text('Rewarded Ads');
+    if (rewardedFinder.evaluate().isEmpty) {
+      await tester.scrollUntilVisible(
+        rewardedFinder,
+        200.0,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+    }
+    expect(rewardedFinder, findsOneWidget);
   });
 }

--- a/packages/native_googleads/ios/native_googleads.podspec
+++ b/packages/native_googleads/ios/native_googleads.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'native_googleads'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/packages/native_googleads/lib/src/banner_ad_widget.dart
+++ b/packages/native_googleads/lib/src/banner_ad_widget.dart
@@ -26,6 +26,11 @@ class BannerAdWidget extends StatefulWidget {
   /// Optional request configuration.
   final AdRequestConfig? requestConfig;
 
+  /// Optional preloaded banner ID returned by `loadBannerAd`.
+  ///
+  /// If provided, the widget will skip loading and render this preloaded ad.
+  final String? preloadedBannerId;
+
   /// Called when the ad loads successfully.
   final VoidCallback? onAdLoaded;
 
@@ -47,6 +52,7 @@ class BannerAdWidget extends StatefulWidget {
     this.onAdFailedToLoad,
     this.onAdClicked,
     this.onAdImpression,
+    this.preloadedBannerId,
   });
 
   @override
@@ -66,6 +72,13 @@ class _BannerAdWidgetState extends State<BannerAdWidget> {
     debugPrint(
         'BannerAdWidget: initState called for adUnitId: ${widget.adUnitId}');
     _setAdHeight();
+    // If a preloaded bannerId is provided, use it directly
+    if (widget.preloadedBannerId != null && widget.preloadedBannerId!.isNotEmpty) {
+      _bannerId = widget.preloadedBannerId;
+      _isLoaded = true;
+      // Attempt to show immediately
+      WidgetsBinding.instance.addPostFrameCallback((_) => _showAd());
+    }
   }
 
   @override
@@ -124,6 +137,7 @@ class _BannerAdWidgetState extends State<BannerAdWidget> {
 
   Future<void> _loadAd() async {
     debugPrint('BannerAdWidget: Starting to load ad');
+    if (_bannerId != null) return; // Already have a preloaded id
     // Validate size before loading
     final validatedSize = _getValidatedSize();
     if (validatedSize != widget.size) {

--- a/packages/native_googleads/lib/src/native_ad_widget.dart
+++ b/packages/native_googleads/lib/src/native_ad_widget.dart
@@ -44,6 +44,11 @@ class NativeAdWidget extends StatefulWidget {
   /// Custom template ID for native ads (optional).
   final String? templateId;
 
+  /// Optional preloaded native ad ID returned by `loadNativeAd`.
+  ///
+  /// If provided, the widget will skip loading and render this preloaded ad.
+  final String? preloadedNativeAdId;
+
   const NativeAdWidget({
     super.key,
     required this.adUnitId,
@@ -55,6 +60,7 @@ class NativeAdWidget extends StatefulWidget {
     this.onAdImpression,
     this.backgroundColor,
     this.templateId,
+    this.preloadedNativeAdId,
   });
 
   @override
@@ -72,7 +78,13 @@ class _NativeAdWidgetState extends State<NativeAdWidget> {
     super.initState();
     debugPrint(
         'NativeAdWidget: initState called for adUnitId: ${widget.adUnitId}');
-    _loadAd();
+    if (widget.preloadedNativeAdId != null && widget.preloadedNativeAdId!.isNotEmpty) {
+      _nativeAdId = widget.preloadedNativeAdId;
+      _isLoaded = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) => _showAd());
+    } else {
+      _loadAd();
+    }
   }
 
   Future<void> _loadAd() async {

--- a/packages/native_googleads/pubspec.yaml
+++ b/packages/native_googleads/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_googleads
 description: A Flutter plugin for integrating Google Mobile Ads (AdMob) using native platform implementations. Supports interstitial and rewarded ads with comprehensive callbacks.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/dvelop42/flutter_native/tree/main/packages/native_googleads
 repository: https://github.com/dvelop42/flutter_native
 issue_tracker: https://github.com/dvelop42/flutter_native/issues


### PR DESCRIPTION
Summary:
- Add preloaded rendering for banner/native widgets via `preloadedBannerId` and `preloadedNativeAdId`.
- Implement production/test ad ID validation policy with warn/strict/disable modes (`setAdIdValidationPolicy`).
- Example: add “Preloaded Banner”, “Preloaded Native”, and “Preloaded Fullscreen Ads” pages; fix overflow and apply graceful failure handling (hide/skip slots).
- Docs: update README and example docs; add production ID validation section.
- Tests: add unit tests for validation policy; fix example widget test (scroll to item).
- Bump package to 0.0.2 and update podspec; add CHANGELOG entry.

Change scope: packages/native_googleads only.
